### PR TITLE
fix for issue #4.

### DIFF
--- a/ci/release-notes.md
+++ b/ci/release-notes.md
@@ -1,0 +1,2 @@
+# Improvements	
+ This release fixes a bug where Prometheus was not properly validaitng and using certs with external domains.

--- a/hooks/check
+++ b/hooks/check
@@ -11,19 +11,32 @@ fi
 
 ok=yes
 vault="secret/$GENESIS_VAULT_PREFIX"
-domain="$(lookup params.static_ip)"
 for cert in nginx/ssl_certificate; do
   if ! safe exists "$vault/$cert"; then
     describe "  #R{✘}  $vault/$cert [#Y{MISSING}]"
     ok=no
   else
-    if safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" >/dev/null 2>&1; then
-      describe "  #G{✔}  $vault/$cert [#G{OK}]"
+    if [[ $(lookup params.external_domain) == $(lookup params.static_ip) ]]; then
+      if safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" >/dev/null 2>&1; then
+        describe "  #G{✔}  $vault/$cert [#G{OK}]"
+      else
+        describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
+        safe x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" 2>&1 | sed -e 's/^/      /';
+        ok=no
+        echo
+      fi
     else
-      describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-      safe x509 validate "$vault/$cert" --for "*.$domain" 2>&1 | sed -e 's/^/      /';
-      ok=no
-      echo
+      if safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.external_domain)" >/dev/null 2>&1; then
+        describe "  #G{✔}  $vault/$cert [#G{OK}]"
+      else
+        describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
+        safe x509 validate "$vault/$cert" --for "$(lookup params.external_domain)" 2>&1 | sed -e 's/^/      /';
+        ok=no
+        echo
+      fi
+      if ! safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" >/dev/null 2>&1; then
+        describe "  #Y{Cert not valid for given ip.}  $vault/$cert [#Y{Warning}]"
+      fi
     fi
   fi
 done;

--- a/hooks/check
+++ b/hooks/check
@@ -18,25 +18,25 @@ for cert in nginx/ssl_certificate; do
     describe "  #R{✘}  $vault/$cert [#Y{MISSING}]"
     ok=no
   else
-    if [[ $domain == $static_ip ]]; then
-      if safe --quiet x509 validate "$vault/$cert" --for $static_ip >/dev/null 2>&1; then
+    if [[ "$domain" == "$static_ip" ]]; then
+      if safe --quiet x509 validate "$vault/$cert" --for "$static_ip" >/dev/null 2>&1; then
         describe "  #G{✔}  $vault/$cert [#G{OK}]"
       else
         describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-        safe x509 validate "$vault/$cert" --for $static_ip 2>&1 | sed -e 's/^/      /';
+        safe x509 validate "$vault/$cert" --for "$static_ip" 2>&1 | sed -e 's/^/      /';
         ok=no
         echo
       fi
     else
-      if safe --quiet x509 validate "$vault/$cert" --for $domain >/dev/null 2>&1; then
+      if safe --quiet x509 validate "$vault/$cert" --for "$domain" >/dev/null 2>&1; then
         describe "  #G{✔}  $vault/$cert [#G{OK}]"
       else
         describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-        safe x509 validate "$vault/$cert" --for $domain 2>&1 | sed -e 's/^/      /';
+        safe x509 validate "$vault/$cert" --for "$domain" 2>&1 | sed -e 's/^/      /';
         ok=no
         echo
       fi
-      if ! safe --quiet x509 validate "$vault/$cert" --for $static_ip >/dev/null 2>&1; then
+      if ! safe --quiet x509 validate "$vault/$cert" --for "$static_ip" >/dev/null 2>&1; then
         describe "  #Y{Cert not valid for given ip.}  $vault/$cert [#Y{Warning}]"
       fi
     fi

--- a/hooks/check
+++ b/hooks/check
@@ -11,30 +11,32 @@ fi
 
 ok=yes
 vault="secret/$GENESIS_VAULT_PREFIX"
+static_ip="$(lookup params.static_ip)"
+domain="$(lookup params.external_domain "$static_ip")"
 for cert in nginx/ssl_certificate; do
   if ! safe exists "$vault/$cert"; then
     describe "  #R{✘}  $vault/$cert [#Y{MISSING}]"
     ok=no
   else
-    if [[ $(lookup params.external_domain) == $(lookup params.static_ip) ]]; then
-      if safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" >/dev/null 2>&1; then
+    if [[ $domain == $static_ip ]]; then
+      if safe --quiet x509 validate "$vault/$cert" --for $static_ip >/dev/null 2>&1; then
         describe "  #G{✔}  $vault/$cert [#G{OK}]"
       else
         describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-        safe x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" 2>&1 | sed -e 's/^/      /';
+        safe x509 validate "$vault/$cert" --for $static_ip 2>&1 | sed -e 's/^/      /';
         ok=no
         echo
       fi
     else
-      if safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.external_domain)" >/dev/null 2>&1; then
+      if safe --quiet x509 validate "$vault/$cert" --for $domain >/dev/null 2>&1; then
         describe "  #G{✔}  $vault/$cert [#G{OK}]"
       else
         describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-        safe x509 validate "$vault/$cert" --for "$(lookup params.external_domain)" 2>&1 | sed -e 's/^/      /';
+        safe x509 validate "$vault/$cert" --for $domain 2>&1 | sed -e 's/^/      /';
         ok=no
         echo
       fi
-      if ! safe --quiet x509 validate "$vault/$cert" --for "$(lookup params.static_ip)" >/dev/null 2>&1; then
+      if ! safe --quiet x509 validate "$vault/$cert" --for $static_ip >/dev/null 2>&1; then
         describe "  #Y{Cert not valid for given ip.}  $vault/$cert [#Y{Warning}]"
       fi
     fi


### PR DESCRIPTION
This is a fix for #4.
If an external domain is specified that is not the static ip used to deploy Prometheus, we now check the validity of that domain and will throw a warning if the ip is not present on the cert.

Tested on lab with:
- a kit generated cert with no external domain specified (ip only)
- a safe generated cert for a test domain but missing the static ip from the san. (to test warning)
- a safe generated cert with a test domain and the correct ip used to deploy Prometheus 