### PR TITLE
Fix for external domain being set to ''monitor cf", external domain not being added to cert san

### DIFF
--- a/hooks/new
+++ b/hooks/new
@@ -67,5 +67,5 @@ EOF
 # If the $external_domain was different from the default (which is $ip), then add
 # it to the env file. Otherwise, don't include it.
 if [ $ip != $external_domain ] ; then
-  printf >>"$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" -- '  external_domain: %s\n' "$f"
+  printf >>"$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" -- '  external_domain: %s\n' "$external_domain"
 fi

--- a/kit.yml
+++ b/kit.yml
@@ -23,3 +23,4 @@ certificates:
         valid_for: 1y
         names:
         - ${params.static_ip}
+        - ${params.external_domain}


### PR DESCRIPTION
- External_domain will no longer be a feature flag
- Having genesis create you a self-signed cert with an external_domain now works.

Note: In cases where the external domain is the static ip the ip will be added to the san twice. This is intentional.