### PR TITLE
Fix external domain support & self-signed certs

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -5,13 +5,15 @@ and Cloudfoundry.
 
 ## Requirements
 
+Genesis version 2.6.8 or higher.
+
 [Node Exporter][1] must be installed on all BOSH VMs you would like to
 monitor. Please consult the README of that repository on how to setup
 the BOSH addon.
 
 [Bosh Exporter][2] requires a UAA account to access BOSH director
 information. This requires that the BOSH director was deployed with
-`bosh-genesis-kit` version `1.1.2`
+`bosh-genesis-kit` version `1.1.2` or higher.
 
 
 ## Features
@@ -29,7 +31,7 @@ information. This requires that the BOSH director was deployed with
 
 * `monitor-cf` - Have Prometheus connect to the CF Firehose to track
   CF app status + more. Requires that the CF installation was deployed
-  with `cf-genesis-kit` version `1.1.0`.
+  with `cf-genesis-kit` version `1.1.0` or higher.
 
 ## Params
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,8 @@
+# Improvements
+* Fix external domain support & self-signed certs
+
+This release fixes prior attempts at automatically signing certificates
+for external domains. It leverages a new feature found in Genesis 
+v.2.6.8. As such, the minimum Genesis version for the Prometheus Genesis
+kit is now 2.6.8
+

--- a/hooks/addon
+++ b/hooks/addon
@@ -27,29 +27,21 @@ visit-prometheus|vp)
     exit 1
   fi
   url=$(exodus prometheus_url)
-  if [[ $(exodus http_auth) == "1" ]]; then
-    password=$(safe get $vault/admin:password)
-    open "https://admin:$password@$url"
-  else
-    open "https://$url"
-  fi
+  password=$(safe get $vault/admin:password)
+  open "https://admin:$password@$url"
   ;;
 
-visit-alertmanager|am)
+visit-alertmanager|va)
   if ! command -v open >/dev/null 2>&1; then
     echo "The 'visit-alertmanager' addon script only works on macOS, currently."
     exit 1
   fi
   url=$(exodus alertmanager_url)
-  if [[ $(exodus http_auth) == "1" ]]; then
-    password=$(safe get $vault/admin:password)
-    open "https://admin:$password@$url"
-  else
-    open "https://$url"
-  fi
+  password=$(safe get $vault/admin:password)
+  open "https://admin:$password@$url"
   ;;
 
-visit-grafana|vc)
+visit-grafana|vg)
   if ! command -v open >/dev/null 2>&1; then
     echo "The 'visit-grafana' addon script only works on macOS, currently."
     exit 1
@@ -64,7 +56,7 @@ visit-grafana|vc)
   open "https://$url"
   ;;
 
-  runtime-config|rc)
+runtime-config|rc)
   cat <<EOF
 releases:
   - name: node-exporter

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -13,13 +13,19 @@ set -eu
 # zero exit code otherwise).
 
 
-validate_features self-signed-cert provided-cert monitor-cf
+validate_features self-signed-cert provided-cert \
+                  monitor-cf
 
 declare -a manifests
 manifests+=( manifests/prometheus.yml )
 
-if want_feature monitor-cf ; then
-  manifests+=( manifests/cf.yml )
-fi
+
+for want in ${GENESIS_REQUESTED_FEATURES}; do
+  case "$want" in
+    monitor-*)
+      manifests+=( manifests/${want}.yml )
+      ;;
+    esac
+done
 
 echo ${manifests[@]}

--- a/hooks/check
+++ b/hooks/check
@@ -18,27 +18,13 @@ for cert in nginx/ssl_certificate; do
     describe "  #R{✘}  $vault/$cert [#Y{MISSING}]"
     ok=no
   else
-    if [[ "$domain" == "$static_ip" ]]; then
-      if safe --quiet x509 validate "$vault/$cert" --for "$static_ip" >/dev/null 2>&1; then
-        describe "  #G{✔}  $vault/$cert [#G{OK}]"
-      else
-        describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-        safe x509 validate "$vault/$cert" --for "$static_ip" 2>&1 | sed -e 's/^/      /';
-        ok=no
-        echo
-      fi
+    if safe --quiet x509 validate "$vault/$cert" --for "$static_ip" --for "$domain" >/dev/null 2>&1; then
+      describe "  #G{✔}  $vault/$cert [#G{OK}]"
     else
-      if safe --quiet x509 validate "$vault/$cert" --for "$domain" >/dev/null 2>&1; then
-        describe "  #G{✔}  $vault/$cert [#G{OK}]"
-      else
-        describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
-        safe x509 validate "$vault/$cert" --for "$domain" 2>&1 | sed -e 's/^/      /';
-        ok=no
-        echo
-      fi
-      if ! safe --quiet x509 validate "$vault/$cert" --for "$static_ip" >/dev/null 2>&1; then
-        describe "  #Y{Cert not valid for given ip.}  $vault/$cert [#Y{Warning}]"
-      fi
+      describe "  #R{✘}  $vault/$cert [#R{INVALID}]"
+      safe x509 validate "$vault/$cert" --for "$static_ip" --for "$domain" 2>&1 | sed -e 's/^/      /';
+      ok=no
+      echo
     fi
   fi
 done;

--- a/hooks/new
+++ b/hooks/new
@@ -36,15 +36,15 @@ describe "" \
 prompt_for external_domain line --default "$ip" \
   'What is the domain you want to use to access Prometheus?' \
 
+# Additional monitoring. In the future we plan to have many additional monitoring
+# features, so we use a list rather than 10+ "Do you want to monitor X?" prompts.
+describe "" \
+  "By default, Prometheus will monitor VM metrics and your BOSH environment. If you want more" \
+  "detail, you can select from the following list of supported exporters to gain insight into" \
+  "software-specific metrics. Some exporters may require additional configuration."
 
-# Monitoring CF Feature
-prompt_for monitor_cf boolean \
-	'Would you like to monitor a CF installation?'
-
-if [ $monitor_cf == "true" ] ; then
-  features+=("monitor-cf")
-fi
-
+prompt_for monitor_features multi-line \
+  "What would you like to monitor? You can choose from: #G{cf}"
 
 cat <<EOF >$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
 kit:
@@ -57,6 +57,19 @@ for f in "${features[@]}" ; do
   printf >>"$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" -- '    - %s\n' "$f"
 done
 
+# We prompt for additional configuration values here, rather than before the
+# first `cat` for code cleanup (we're checking if monitor_features exist once
+# rather than twice) reasons.
+
+if [[ ! -z "${monitor_features:-}" ]] ; then
+  # In the future, if we have exporters that need additional configuration,
+  # those prompts would go here.
+  for monitor in "${monitor_features[@]}"; do
+    # Append feature flags to manifest
+    printf >>"$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" -- '    - %s\n' "monitor-$monitor"
+  done
+fi
+
 cat <<EOF >>$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
 params:
   env:   $GENESIS_ENVIRONMENT
@@ -66,6 +79,6 @@ EOF
 
 # If the $external_domain was different from the default (which is $ip), then add
 # it to the env file. Otherwise, don't include it.
-if [ $ip != $external_domain ] ; then
-  printf >>"$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" -- '  external_domain: %s\n' "$f"
+if [[ $ip != $external_domain ]] ; then
+  printf >>"$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" -- '  external_domain: %s\n' "$external_domain"
 fi

--- a/kit.yml
+++ b/kit.yml
@@ -5,7 +5,7 @@ docs:    https://github.com/cloudfoundry-community/prometheus-boshrelease
 code:    https://github.com/genesis-community/prometheus-genesis-kit
 
 # 2.6.0 was our last big feature bump
-genesis_min_version: 2.6.0
+genesis_min_version: 2.6.8
 
 credentials:
   base:
@@ -23,3 +23,4 @@ certificates:
         valid_for: 1y
         names:
         - ${params.static_ip}
+        - ${maybe:params.external_domain}

--- a/manifests/monitor-cf.yml
+++ b/manifests/monitor-cf.yml
@@ -9,7 +9,7 @@ meta:
   uaa_client_secret:     (( vault meta.cf_firehose_uaa_vault ))
 
 instance_groups:
-- name:      prometheus
+- name: prometheus
   jobs:
   - name: cf_exporter
     release: prometheus


### PR DESCRIPTION
This commit fixes prior attempts at automatically signing certificates for external domains. It leverages the new Genesis 2.6.8 "maybe" feature, which allows dynamic certificate SAN additions depending on manifest values. This way, the certificates can be optionally signed for the external domain, should that value exist in the manifest.

This commit also fixes minor bugs found during testing, including typos in the `addon` hook.

Finally, this commit also includes structural changes to accommodate future feature additions to the kit. Rather than prompting the user for each additional monitoring feature, it is instead a "word cloud" with a multi-line prompt statement. While currently unimplemented, additional configuration prompts that other features may need are easily implemented (which would be inserted as a `case` statement on `hook` L65).

Release notes have been written and MANUAL.md has been slightly tweaked to reflect current changes.