### PR TITLE
Add Doppler connection string parameters

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -59,6 +59,12 @@ information. This requires that the BOSH director was deployed with
   deployment. Can be either a FQDN or IP address. (default: value of
   `static_ip`)
 
+### `monitor-cf` Feature Configuration
+
+* `doppler_port` - The port that CF Doppler listens on. (defaut: `4443`)
+* `doppler_url` - The URL to use to connect to CF Doppler (default is extracted
+  from Genesis Exodus data, which is `doppler.` + your CF system domain)
+
 ## Cloud Config
 
 The Prometheus Genesis Kit requires a static IP address to be defined

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+# Improvements
+
+We've added two new parameters to the `monitor-cf` feature, which are:
+* `doppler_port` - The port that CF Doppler listens on. (defaut: `4443`)
+* `doppler_url` - The URL to use to connect to CF Doppler (default is extracted
+  from Genesis Exodus data, which is `doppler.` + your CF system domain)

--- a/manifests/monitor-cf.yml
+++ b/manifests/monitor-cf.yml
@@ -7,6 +7,10 @@ meta:
   cf_firehose_uaa_vault: (( vault "secret/exodus/" meta.bosh_exodus_path "/cf:vaulted_uaa_clients" ))
   uaa_client_id:         firehose
   uaa_client_secret:     (( vault meta.cf_firehose_uaa_vault ))
+  doppler_default_url:   (( concat "doppler." meta.cf_system_domain ))
+  doppler_url:           (( grab params.doppler_url  || meta.doppler_default_url ))
+  doppler_port:          (( grab params.doppler_port || 4443 ))
+  doppler_full_url:      (( concat "wss://" meta.doppler_url ":" meta.doppler_port ))
 
 instance_groups:
 - name: prometheus
@@ -29,7 +33,7 @@ instance_groups:
     properties:
       firehose_exporter:
         doppler:
-          url: (( concat "wss://doppler." meta.cf_system_domain ":4443" ))
+          url: (( grab meta.doppler_full_url ))
           subscription_id: (( grab params.env ))
           max_retry_count: 300
         uaa:


### PR DESCRIPTION
This PR allows folks with LBs in front of CF that don't allow 4443 traffic through to configure their own way of accessing the Doppler output.