### PR TITLE
Bump Prometheus and Postgres versions

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -8,6 +8,6 @@
 
 | Release                | Version | Release Date |
 | ---------------------- | ------- |----------|
-| prometheus-boshrelease | [26.2.1](https://github.com/bosh-prometheus/prometheus-boshrelease/releases/tag/v26.2.0) | Jan 22, 2020 |
+| prometheus-boshrelease | [26.2.0](https://github.com/bosh-prometheus/prometheus-boshrelease/releases/tag/v26.2.0) | Jan 22, 2020 |
 | postgres-release       | [40](https://github.com/cloudfoundry/postgres-release/releases/tag/v40) | Dec 6, 2019 |
 | node-exporter          | [4.2.0](https://github.com/bosh-prometheus/node-exporter-boshrelease/releases/tag/v4.2.0) | Aug 29, 2019 |

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,13 @@
+# Release Changes
+
+- Prometheus updated to 26.2.0 from 26.1.0
+- Postgres updated to 40 from 39
+
+
+# Components
+
+| Release                | Version | Release Date |
+| ---------------------- | ------- |----------|
+| prometheus-boshrelease | [26.2.1](https://github.com/bosh-prometheus/prometheus-boshrelease/releases/tag/v26.2.0) | Jan 22, 2020 |
+| postgres-release       | [40](https://github.com/cloudfoundry/postgres-release/releases/tag/v40) | Dec 6, 2019 |
+| node-exporter          | [4.2.0](https://github.com/bosh-prometheus/node-exporter-boshrelease/releases/tag/v4.2.0) | Aug 29, 2019 |

--- a/manifests/releases.yml
+++ b/manifests/releases.yml
@@ -1,10 +1,10 @@
 releases:
 - name:    postgres
-  version: "39"
+  version: "40"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=" releases.postgres.version ))
-  sha1:    8ff395540e77a461322a01c41aa68973c10f1ffb
+  sha1:    343f04f1594c57ecea65638802e94e311cd72688
 
 - name:    prometheus
-  version: 26.1.0
-  url:     (( concat "https://github.com/bosh-prometheus/prometheus-boshrelease/releases/download/v" releases.prometheus.version "/prometheus-" releases.prometheus.version ".tgz" ))
-  sha1:    cc4087422e1f9c3c2e8fd553a1f9f81d9fcb380d
+  version: 26.2.0
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=" releases.prometheus.version ))
+  sha1:    9a57a9c74ebcb53baaa9cf8eb22f8ef353460169


### PR DESCRIPTION
Bump Postres to 40, bump prometheus to 26.2.0 (also updated the download to bosh.io)

Upgrade and fresh deploy tested and working. 