### PR TITLE
Support stemcell_os / stemcell_version params

### DIFF
--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -489,8 +489,8 @@ instance_groups:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
-  version: latest
+  os:      (( grab params.stemcell_os      || "ubuntu-xenial" ))
+  version: (( grab params.stemcell_version || "latest" ))
 
 update:
   canaries: 1


### PR DESCRIPTION
This brings the Prometheus kit in line with current kit standards.

It also fixes #20, and makes @krutten happy.