### PR TITLE
Release v1.10.0

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -84,7 +84,8 @@ addons:
         release: node-exporter
     include:
       stemcell:
-        - os: ubuntu-trusty
+        - os: ubuntu-jammy
+        - os: ubuntu-bionic
         - os: ubuntu-xenial
     properties: {}
 EOF

--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -489,7 +489,7 @@ instance_groups:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -489,8 +489,8 @@ instance_groups:
 
 stemcells:
 - alias: default
-  os: ubuntu-jammy
-  version: latest
+  os:      (( grab params.stemcell_os      || "ubuntu-jammy" ))
+  version: (( grab params.stemcell_version || "latest" ))
 
 update:
   canaries: 1

--- a/manifests/releases/prometheus.yml
+++ b/manifests/releases/prometheus.yml
@@ -2,6 +2,7 @@
   path: /releases?/name=prometheus?
   value:
     name: prometheus
-    version: 26.6.0
-    url: https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=26.6.0
-    sha1: 33b4a873648e268b7a24d64e787f08816f85a3c0
+    version: 27.2.0
+    url: https://github.com/bosh-prometheus/prometheus-boshrelease/releases/download/v27.2.0/prometheus-27.2.0.tgz
+    sha1: 8e5a6efcab2bb0323c111ce469a0219dfb3204e4
+


### PR DESCRIPTION
# Improvements

* Update kit to use Jammy Stemcell

# Updates

* Bump Prometheus-boshrelease to 27.2.0 for OpenSSL 3.x support