### PR TITLE
Firehose exporter rewrite

### DIFF
--- a/manifests/monitor-cf-v2.yml
+++ b/manifests/monitor-cf-v2.yml
@@ -38,11 +38,13 @@ instance_groups:
 
   - name: firehose_exporter
     release: prometheus
+    consumes:
+      reverse_log_proxy:
+        deployment:       (( grab params.cf_deployment_name || meta.default_cf_deployment_name ))
+        from: reverse_log_proxy
     properties:
       firehose_exporter:
         logging:
-          url: (( grab params.rlp_gateway_url || meta.default_urls.rlp_gateway ))
-          use_legacy_firehose: false
           tls:
             ca:   (( grab meta.loggregator_tls_rlp.ca ))
             cert: (( grab meta.loggregator_tls_rlp.cert ))

--- a/manifests/monitor-cf-v2.yml
+++ b/manifests/monitor-cf-v2.yml
@@ -11,7 +11,6 @@ meta:
   cf_exporter_username:       cf_exporter
   cf_exporter_secret:         (( vault meta.cf_exodus_src "cf_exporter_secret" ))
   firehose_exporter_username: firehose_exporter
-  firehose_exporter_secret:   (( vault meta.cf_exodus_src "firehose_exporter_secret" ))
   default_urls:
     rlp_gateway: (( concat "https://log-stream." meta.cf_system_domain ))
     api:         (( concat "https://api." meta.cf_system_domain ))
@@ -50,11 +49,6 @@ instance_groups:
             key:  (( grab meta.loggregator_tls_rlp.key ))
         doppler:
           subscription_id: (( grab genesis.env ))
-          max_retry_count: 300
-        uaa:
-          url:             (( grab params.uaa_url || meta.default_urls.uaa ))
-          client_id:       (( grab meta.firehose_exporter_username ))
-          client_secret:   (( grab meta.firehose_exporter_secret ))
         metrics:
           environment:     (( grab genesis.env ))
         skip_ssl_verify:   (( grab params.skip_ssl_validation || false ))

--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -178,7 +178,9 @@ instance_groups:
             replacement: ${1}:9186
             source_labels: [ __address__ ]
             target_label: __address__
-
+          scheme: https
+          tls_config:
+            insecure_skip_verify: true
         - job_name: grafana
           file_sd_configs:
           - files: [ /var/vcap/store/bosh_exporter/bosh_target_groups.json ]


### PR DESCRIPTION
Remove Firehose Exporter secret configuration
- Removes `firehose_exporter_secret` from the meta
 section
- Removes UAA client ID and secret for the
Firehose Exporter


Update RLP link configuration for Firehose Exportr
- Adds the `consumes` section for
`reverse_log_proxy`


Add HTTPS configuration for Firehose Exporter
- Adds `scheme: https`
- Adds `tls_config` with
`insecure_skip_verify: true`