### PR TITLE
Adopt prometheus boshrelease 31.2.1 with v3 server

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -98,6 +98,35 @@ kit:
     - legacy-firehose
 ```
 
+#### `monitor-cf-bbs`
+
+Adds running-instance metrics to the `monitor-cf` feature. cf_exporter
+2.x reads running-instance counts from Diego BBS rather than the retired
+CF v2 API, so without this the `cf_application_instances_running` metric
+and the alerts that depend on it are unavailable.
+
+This is opt-in because it needs the CF deployment to publish its BBS
+client certificate to exodus. Enable it once the cf-genesis-kit release
+in use exports `bbs_ca`, `bbs_client_cert` and `bbs_client_key`. The
+feature colocates a `bosh-dns-aliases` job so the BBS internal name
+resolves from the prometheus VM, which keeps the connection verified.
+
+Requirements:
+- `monitor-cf` feature (cf v2.x)
+- cf-genesis-kit release that exports the bbs client material to exodus
+
+Configuration parameters:
+- `cf_bbs_api_url`: BBS API endpoint (default: https://bbs.service.cf.internal:8889)
+- `cf_network`: BOSH network of the CF diego-api instances (default: derived from CF exodus)
+
+Example:
+```yaml
+kit:
+  features:
+    - monitor-cf
+    - monitor-cf-bbs
+```
+
 #### `monitor-credhub`
 
 Enables monitoring of CredHub metrics and health.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -326,6 +326,6 @@ Recommendations:
 ## References
 
 - [Prometheus BOSH Release](https://github.com/cloudfoundry-community/prometheus-boshrelease)
-- [Node Exporter BOSH Release](https://github.com/bosh-prometheus/node-exporter-boshrelease)
+- [Node Exporter BOSH Release](https://github.com/cloudfoundry/node-exporter-boshrelease)
 - [Prometheus Documentation](https://prometheus.io/docs/introduction/overview/)
 - [Grafana Documentation](https://grafana.com/docs/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each component is exposed via HTTPS with basic authentication. The kit configure
 
 - Genesis 2.7.10 or higher
 - BOSH Director with UAA
-- [Node Exporter](https://github.com/bosh-prometheus/node-exporter-boshrelease) should be deployed as a BOSH addon to collect system metrics from all VMs
+- [Node Exporter](https://github.com/cloudfoundry/node-exporter-boshrelease) should be deployed as a BOSH addon to collect system metrics from all VMs
 - For monitoring Cloud Foundry: A CF deployment created with cf-genesis-kit v1.1.0 or higher
 - For monitoring BOSH: A BOSH director deployed with bosh-genesis-kit v1.1.2 or higher
 
@@ -157,5 +157,5 @@ For common issues and solutions, please refer to the `docs/troubleshooting.md` d
 This Genesis Kit is released under the MIT license.
 
 [1]: https://github.com/cloudfoundry-community/prometheus-boshrelease
-[2]: https://github.com/bosh-prometheus/node-exporter-boshrelease
+[2]: https://github.com/cloudfoundry/node-exporter-boshrelease
 [3]: MANUAL.md

--- a/hooks/blueprint.pm
+++ b/hooks/blueprint.pm
@@ -44,12 +44,27 @@ sub perform {
 					? "manifests/monitor-cf-v2.yml"
 					:	"manifests/monitor-cf.yml"
 			);
+			# BBS metrics are opt-in: cf_exporter reaches Diego BBS for
+			# running-instance counts, which needs the cf kit to export
+			# the bbs client cert to exodus first.
+			if ($cf_v2 && $self->want_feature('monitor-cf-bbs')) {
+				$self->add_files(
+					"manifests/monitor-cf-bbs.yml",
+					"manifests/releases/bosh-dns-aliases.yml"
+				);
+			}
 			if ($self->want_feature('legacy-firehose')) {
 				bail(
 					"legacy-firehose is not available for cf v2.x deployments"
 				) if $cf_v2;
 				$self->add_files("manifests/legacy-firehose.yml");
 			}
+
+		} elsif ($feature =~ /^(monitor-cf-bbs)$/) {
+			# Wired by the monitor-cf feature above; only valid with it.
+			bail(
+				"monitor-cf-bbs requires the monitor-cf feature"
+			) unless $self->want_feature('monitor-cf');
 
 		} elsif ($feature =~ /^(monitor-*)$/) {
 			bail(

--- a/manifests/monitor-cf-bbs.yml
+++ b/manifests/monitor-cf-bbs.yml
@@ -1,0 +1,39 @@
+---
+# Opt-in BBS metrics for cf_exporter (feature: monitor-cf-bbs).
+#
+# cf_exporter 2.x sources running-instance counts from Diego BBS rather
+# than the retired CF v2 API. Reaching BBS needs a client cert the cf
+# kit exports to exodus and a bosh-dns alias so the canonical name
+# resolves from the prometheus VM. Enable only once the cf kit exports
+# bbs_ca / bbs_client_cert / bbs_client_key to exodus.
+meta:
+  bbs_tls:
+    ca:   (( vault meta.cf_exodus_src "bbs_ca" ))
+    cert: (( vault meta.cf_exodus_src "bbs_client_cert" ))
+    key:  (( vault meta.cf_exodus_src "bbs_client_key" ))
+  default_cf_network: (( vault meta.cf_exodus_src "core_network" ))
+  cf_network:         (( grab params.cf_network || meta.default_cf_network ))
+
+instance_groups:
+- name: prometheus
+  jobs:
+  - name: cf_exporter
+    properties:
+      cf_exporter:
+        bbs:
+          api_url:         (( grab params.cf_bbs_api_url || "https://bbs.service.cf.internal:8889" ))
+          ca:              (( grab meta.bbs_tls.ca ))
+          cert:            (( grab meta.bbs_tls.cert ))
+          key:             (( grab meta.bbs_tls.key ))
+          skip_ssl_verify: false
+  - name: bosh-dns-aliases
+    release: bosh-dns-aliases
+    properties:
+      aliases:
+      - domain: bbs.service.cf.internal
+        targets:
+        - query: '*'
+          instance_group: diego-api
+          deployment: (( grab params.cf_deployment_name || meta.default_cf_deployment_name ))
+          network: (( grab meta.cf_network ))
+          domain: bosh

--- a/manifests/monitor-cf-v2.yml
+++ b/manifests/monitor-cf-v2.yml
@@ -76,7 +76,7 @@ instance_groups:
             - /var/vcap/jobs/cloudfoundry_dashboards/prometheus*.json
 
 
-  - name: prometheus2
+  - name: prometheus
     properties:
       prometheus:
         rule_files:

--- a/manifests/monitor-cf.yml
+++ b/manifests/monitor-cf.yml
@@ -67,7 +67,7 @@ instance_groups:
             - /var/vcap/jobs/cloudfoundry_dashboards/prometheus*.json
 
 
-  - name: prometheus2
+  - name: prometheus
     properties:
       prometheus:
         rule_files:

--- a/manifests/monitor-credhub.yml
+++ b/manifests/monitor-credhub.yml
@@ -37,7 +37,7 @@ instance_groups:
   - name: credhub_dashboards
     release: prometheus
 
-  - name: prometheus2
+  - name: prometheus
     properties:
       prometheus:
         rule_files:

--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -58,7 +58,7 @@ instance_groups:
         route:
           receiver: default
 
-  - name: prometheus2
+  - name: prometheus
     release: prometheus
     properties:
       prometheus:

--- a/manifests/releases/bosh-dns-aliases.yml
+++ b/manifests/releases/bosh-dns-aliases.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /releases?/name=bosh-dns-aliases?
+  value:
+    name: bosh-dns-aliases
+    version: "0.0.4"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4"
+    sha1: "55b3dced813ff9ed92a05cda02156e4b5604b273"

--- a/manifests/releases/bpm.yml
+++ b/manifests/releases/bpm.yml
@@ -2,6 +2,6 @@
   path: /releases?/name=bpm?
   value:
     name: "bpm"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.20"
-    version: "1.4.20"
-    sha1: "00223345c70d5629d35008e88c42bf4482bdf766"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.30"
+    version: "1.4.30"
+    sha1: "dc0138c87ea5854fea4e21e4ce2e7d110fca52b8"

--- a/manifests/releases/postgres.yml
+++ b/manifests/releases/postgres.yml
@@ -2,6 +2,6 @@
   path: /releases?/name=postgres?
   value:
     name: postgres
-    version: "53"
-    url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=53"
-    sha1: "f130ebc9c4abf023e955e2fc7b7ea3bb6a64682a"
+    version: "54.0.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=54.0.0"
+    sha1: "dbbe92802e79900010bc2cc019833108519a110e"

--- a/manifests/releases/prometheus.yml
+++ b/manifests/releases/prometheus.yml
@@ -2,6 +2,6 @@
   path: /releases?/name=prometheus?
   value:
     name: prometheus
-    version: "30.9.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/prometheus-boshrelease?v=30.9.0"
-    sha1: "8daad925712c891e275da7d5e1e52867dca8aa98"
+    version: "31.2.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/prometheus-boshrelease?v=31.2.1"
+    sha1: "f821f256c1da32c3f7e94f6a459873bf91a65618"


### PR DESCRIPTION
Moves the kit to prometheus boshrelease 31.2.1, which ships the
Prometheus v3 server. The instance group keeps its name, so the
job swaps from prometheus2 to prometheus in place and the
persistent disk stays attached. Companion releases move with it,
bpm to 1.4.30 and postgres to 54.0.0.

Upgrades must stage through 30.9.0 first (released as v2.1.0)
before moving to any v31 release.

## Opt-in BBS metrics

cf_exporter 2.x, which ships with 31.2.1, reads running-instance
counts from Diego BBS instead of the retired CF v2 API. Without a
BBS connection the cf_application_instances_running metric and the
two cf_apps alerts that use it are unavailable.

This adds a monitor-cf-bbs feature that wires cf_exporter to BBS.
It is opt-in because it needs the CF deployment to export its BBS
client certificate to exodus, which the cf-genesis-kit does in a
companion change. Without the feature the deploy is unaffected and
behaves as stock 31.2.1.

## Known issue

Three latency panels in the Apps: Latency dashboard show no data
on v3 because they reference integer histogram bucket labels that
v3 normalizes to floats. The fix is upstream in the boshrelease,
tracked in cloudfoundry/prometheus-boshrelease#594.